### PR TITLE
Add json upload option

### DIFF
--- a/app/server/templates/admin/dataset_upload.html
+++ b/app/server/templates/admin/dataset_upload.html
@@ -27,11 +27,12 @@
           <div class="section">
             <div class="control">
               <label class="radio mb10">
-                <input type="radio" name="format" checked> Upload a TXT file from your computer
+                <input type="radio" name="format" value="csv" checked> Upload a TXT file from your computer<br>
+                <input type="radio" name="format" value="json"> Upload a JSON file from your computer<br>
               </label>
               <div class="file has-name is-small mb20">
                 <label class="file-label">
-                  <input class="file-input" type="file" ref="file" name="csv_file" required v-on:change="handleFileUpload()">
+                  <input class="file-input" type="file" ref="file" name="file" required v-on:change="handleFileUpload()">
                   <span class="file-cta">
                     <span class="file-icon">
                       <i class="fas fa-upload"></i>

--- a/app/server/views.py
+++ b/app/server/views.py
@@ -1,4 +1,5 @@
 import csv
+import json
 from io import TextIOWrapper
 
 from django.urls import reverse
@@ -56,17 +57,28 @@ class DataUpload(SuperUserMixin, LoginRequiredMixin, TemplateView):
 
     def post(self, request, *args, **kwargs):
         project = get_object_or_404(Project, pk=kwargs.get('project_id'))
+        import_format = request.POST['format']
         try:
-            form_data = TextIOWrapper(request.FILES['csv_file'].file, encoding='utf-8')
-            if project.is_type_of(Project.SEQUENCE_LABELING):
-                Document.objects.bulk_create([Document(
-                    text=line.strip(),
-                    project=project) for line in form_data])
-            else:
-                reader = csv.reader(form_data)
-                Document.objects.bulk_create([Document(
-                    text=line[0].strip(),
-                    project=project) for line in reader])
+            if import_format == 'csv':
+                form_data = TextIOWrapper(
+                    request.FILES['file'].file, encoding='utf-8')
+                if project.is_type_of(Project.SEQUENCE_LABELING):
+                    Document.objects.bulk_create([
+                        Document(text=line.strip(), project=project)
+                        for line in form_data
+                    ])
+                else:
+                    reader = csv.reader(form_data)
+                    Document.objects.bulk_create([
+                        Document(text=line[0].strip(), project=project)
+                        for line in reader
+                    ])
+            elif import_format == 'json':
+                form_data = json.load(request.FILES['file'].file)
+                Document.objects.bulk_create([
+                    Document(text=entry, project=project)
+                    for entry in form_data
+                ])
             return HttpResponseRedirect(reverse('dataset', args=[project.id]))
         except:
             return HttpResponseRedirect(reverse('upload', args=[project.id]))

--- a/app/server/views.py
+++ b/app/server/views.py
@@ -76,7 +76,7 @@ class DataUpload(SuperUserMixin, LoginRequiredMixin, TemplateView):
             elif import_format == 'json':
                 form_data = json.load(request.FILES['file'].file)
                 Document.objects.bulk_create([
-                    Document(text=entry, project=project)
+                    Document(text=entry.strip(), project=project)
                     for entry in form_data
                 ])
             return HttpResponseRedirect(reverse('dataset', args=[project.id]))


### PR DESCRIPTION
Add the ability to upload documents in JSON format. For example:

```
[
    "Document 1 text",
    "Document 2 text"
]
```

This has the added benefit of allowing documents to contain both newline characters and commas, which the previous csv based method of upload did not support.